### PR TITLE
Detect double tap on iOS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
     <title>Pixelm</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>

--- a/src/App.elm
+++ b/src/App.elm
@@ -293,14 +293,18 @@ update msg model =
                 )
 
         SelectFrame frame ->
-            ( { model | frames = SelectionList.select frame model.frames }
+            ( { model
+                | frames = SelectionList.select frame model.frames
+              }
             , Cmd.none
             )
 
         DeleteFrame frame ->
             ( { model
                 | history = History.push model.frames model.history
-                , frames = SelectionList.deleteCurrent <| SelectionList.select frame model.frames
+                , frames =
+                    SelectionList.deleteCurrent <|
+                        SelectionList.select frame model.frames
                 , modalConfig = NoModal
               }
             , Cmd.none
@@ -314,7 +318,8 @@ update msg model =
                 ( { model
                     | history = History.push model.frames model.history
                     , frames =
-                        SelectionList.insertAfterCurrent copy <| SelectionList.select frame model.frames
+                        SelectionList.insertAfterCurrent copy <|
+                            SelectionList.select frame model.frames
                     , frameSequence = model.frameSequence + 1
                     , modalConfig = NoModal
                   }
@@ -719,8 +724,8 @@ viewFrame frameType frame =
                 , if frameType == FramePreview then
                     []
                   else
-                    [ HE.onClick <| SelectFrame frame
-                    , HE.onDoubleClick <| ShowFrameModal frame
+                    [ Events.onSingleOrDoubleClick (SelectFrame frame) (ShowFrameModal frame)
+                    , Events.prepareDoubleClick
                     ]
                 ]
     in

--- a/src/Events.elm
+++ b/src/Events.elm
@@ -41,10 +41,8 @@ decodeOffset =
         (Json.field "offsetTop" Json.int)
 
 
-
--- Android's Touch.clientX/Y are float instead of int
-
-
+{-| Android's Touch.clientX/Y are float instead of int.
+-}
 decodeClientPos : Json.Decoder ( Int, Int )
 decodeClientPos =
     Json.map2 (,)
@@ -96,15 +94,17 @@ onDrop msg =
     HE.onWithOptions "drop" prevent <| Json.succeed msg
 
 
+{-| HACK: Double tap support on iOS
 
--- HACK: Double tap support on iOS
--- iOS does not support `dblclick` event. To detect double tap on iOS, the event
--- handler below sets a flag to the clicked element and deletes it in a short
--- amount of time. The other event handler uses a JSON decoder to check if the
--- data exists and returns a message for double click if the flag exists.
--- Otherwise it just returns a message for single click.
+iOS does not support `dblclick` event. To detect double tap on iOS:
 
+  - `prepareDoubleClick` sets a flag to the clicked element's `dataset` and
+    deletes it in a short amount of time.
+  - `onSingleOrDoubleClick` uses a JSON decoder to check if the flag exists
+    and returns a message for double click if the flag exists. Otherwise it
+    just returns a message for single click.
 
+-}
 prepareDoubleClick : Html.Attribute msg
 prepareDoubleClick =
     HA.attribute "onclick" prepareScript
@@ -117,9 +117,9 @@ prepareScript =
         , "setTimeout(function () {"
         , "  if (el.dataset.timer) { clearTimeout(parseInt(el.dataset.timer, 10)); }"
         , "  el.dataset.timer = setTimeout(function () {"
-        , "    el.dataset.clicked = false;"
+        , "    delete el.dataset.clicked;"
         , "  }, 500);"
-        , "  el.dataset.clicked = true;"
+        , "  el.dataset.clicked = 'true';"
         , "});"
         ]
 

--- a/src/Events.elm
+++ b/src/Events.elm
@@ -126,23 +126,30 @@ prepareScript =
 
 onSingleOrDoubleClick : msg -> msg -> Html.Attribute msg
 onSingleOrDoubleClick singleMessage doubleMessage =
-    HE.on "click" <|
-        Json.oneOf
-            [ decodeClicked doubleMessage
-            , Json.succeed singleMessage
-            ]
+    let
+        decodeDoubleOrNot =
+            Json.oneOf
+                [ decodeClicked
+                , Json.succeed False
+                ]
+
+        getMessage isDoubleClick =
+            if isDoubleClick then
+                doubleMessage
+            else
+                singleMessage
+    in
+        HE.on "click" <|
+            Json.map getMessage decodeDoubleOrNot
 
 
-decodeClicked : msg -> Json.Decoder msg
-decodeClicked msg =
+decodeClicked : Json.Decoder Bool
+decodeClicked =
     let
         decodeClicked =
             Json.field "dataset" <| Json.field "clicked" Json.string
 
         isTrue x =
-            if x == "true" then
-                Json.succeed msg
-            else
-                Json.fail "not clicked"
+            x == "true"
     in
-        Json.andThen isTrue <| Json.field "currentTarget" decodeClicked
+        Json.map isTrue <| Json.field "currentTarget" decodeClicked

--- a/src/Events.elm
+++ b/src/Events.elm
@@ -139,7 +139,7 @@ onSingleOrDoubleClick singleMessage doubleMessage =
             else
                 singleMessage
     in
-        HE.on "click" <|
+        HE.onWithOptions "click" prevent <|
             Json.map getMessage decodeDoubleOrNot
 
 


### PR DESCRIPTION
Fixes #19 

- [x] Detect double tap on iOS
  - Super nasty hack: Set a "clicked" flag with a JavaScript string on the "onclick" attribute and read it with a JSON decoder.
- [x] Fix a newly introduced bug on frame selection
  - It seems that `SelectFrame` message is sent with a outdated frame data when a frame is clicked. It is caused by the change of this PR because it doesn't happen on `master`. However, it happens even without the clicked flag handler hack.
- [x] Prevent zoom-in by double tap