### PR TITLE
Use CSS animation for animation preview

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -155,16 +155,23 @@ body {
   cursor: pointer;
 }
 
-.frame--preview {
-  margin-right: 20px;
-}
-
 .frame--selected {
   border-color: #000;
 }
 
 .frame--plus img {
   padding-top: 15px;
+}
+
+.frame-preview {
+  margin-right: 20px;
+  overflow: hidden;
+  position: relative;
+}
+
+.frame-preview__inner {
+  display: flex;
+  position: relative;
 }
 
 /* https://www.w3schools.com/howto/howto_css_modals.asp */


### PR DESCRIPTION
Remove the `Time.every` subscription for animation preview. It's good for performance because update & view are called less frequently now.

`@keyframes` name has to be unique to its content at least on iOS Safari. It doesn't need to be unique on Desktop Chrome though.